### PR TITLE
fix(import): drop unsupported table_name kwarg from PyArchInit import

### DIFF
--- a/import_operators/import_EMdb.py
+++ b/import_operators/import_EMdb.py
@@ -71,7 +71,6 @@ class EM_OT_import_3dgis_database(bpy.types.Operator):
                     'import_type': import_type,
                     'filepath': em_tools.pyarchinit_db_path,
                     'mapping_name': em_tools.pyarchinit_mapping,
-                    'table_name': em_tools.pyarchinit_table,
                     'mode': '3DGIS'
                 }
             elif import_type == "generic_xlsx":

--- a/import_operators/importer_registry.py
+++ b/import_operators/importer_registry.py
@@ -80,7 +80,7 @@ IMPORTER_REGISTRY = {
     'pyarchinit': ImporterConfig(
         importer_class=PyArchInitImporter,
         required_params=['filepath', 'mapping_name'],
-        optional_params=['table_name']
+        optional_params=[]
     ),
 
     # ✅ EXTENSIBILITY: Adding new formats is easy - just add entry here:


### PR DESCRIPTION
## Summary

PyArchInit imports currently fail at runtime with:

```
TypeError: PyArchInitImporter.__init__() got an unexpected keyword argument 'table_name'
```

`PyArchInitImporter.__init__` in s3dgraphy (both PyPI `1.5.2` and the `s3dgraphy_v1.6dev` branch) accepts only `filepath`, `mapping_name`, `overwrite`, `existing_graph`. The addon-side registry was passing an extra `table_name` kwarg that the importer never declared.

The target SQLite table is already declared inside the mapping JSON, e.g.:

```json
"table_settings": {
  "format_type": "sqlite",
  "table_name": "us_table"
}
```

so the kwarg is redundant. Dropping it on the addon side restores PyArchInit imports.

## Changes

- `import_operators/importer_registry.py` — remove `table_name` from `optional_params` for the `pyarchinit` entry
- `import_operators/import_EMdb.py` — stop passing `table_name` in the 3DGIS settings builder

## Test plan

- [x] Reproduce: try to import a pyArchInit SQLite database in 3D GIS mode → TypeError on `master` of `EM-tools_v1.6.0_dev`
- [x] Apply patch, rebuild extension (`./em.sh build dev`), reinstall in Blender 5.1.2
- [x] Re-run pyArchInit import → completes successfully, US nodes populated in the graph

## Notes

The `pyarchinit_table` EnumProperty (US / SITE / PERIODIZATION) in the UI is preserved, but only `US` works out of the box because `s3dgraphy/mappings/pyarchinit/` only ships `pyarchinit_us_mapping.json`. Adding mappings for SITE and PERIODIZATION (and wiring the enum to select the right mapping name) would be a separate change. This PR keeps scope to restoring the broken import path.