### PR TITLE
feat(pyarchinit): reverse-export EM graph to PyArchInit DB (Sub-3 of #27)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -192,6 +192,23 @@ class ExportVars(PropertyGroup):
         description="Expand/Collapse Emviq export options",
         default=False
     ) # type: ignore
+
+    # PyArchInit DB reverse-export (issue #27, Sub-3)
+    pyarchinit_expanded: BoolProperty(
+        name="Show PyArchInit DB export options",
+        description="Expand/Collapse PyArchInit DB export options",
+        default=False
+    ) # type: ignore
+    pyarchinit_export_sito: StringProperty(
+        name="Site",
+        description="PyArchInit site name (sito) the graph is written under",
+        default=""
+    ) # type: ignore
+    pyarchinit_export_create_epochs: BoolProperty(
+        name="Create missing epochs",
+        description="Auto-create periodizzazione rows for epochs not yet in the DB",
+        default=False
+    ) # type: ignore
     heriverse_project_name: StringProperty(
         name="Project Name",
         description="Name of the Heriverse project",

--- a/em_props.py
+++ b/em_props.py
@@ -938,6 +938,61 @@ class EM_Tools(PropertyGroup):
         update=_update_pyarchinit_db_path,
     )  # type: ignore
 
+    # ----------------------------------------------------------
+    # PyArchInit connection mode (issue #27, Sub-2).
+    # SQLite (the historical default) vs PostgreSQL/PostGIS. The
+    # password is held in a SKIP_SAVE field so it is NEVER written to
+    # the .blend; persistence is delegated to the OS keychain via the
+    # pyarchinit_connection module.
+    # ----------------------------------------------------------
+    pyarchinit_connection_mode: EnumProperty(
+        name="Connection",
+        description="Read pyArchInit from a SQLite file or a PostgreSQL/PostGIS server",
+        items=[
+            ("sqlite", "SQLite", "Local pyArchInit SQLite/SpatiaLite database file"),
+            ("postgres", "PostgreSQL", "Remote pyArchInit PostgreSQL/PostGIS database"),
+        ],
+        default="sqlite",
+    )  # type: ignore
+
+    pyarchinit_pg_host: StringProperty(
+        name="Host",
+        description="PostgreSQL server host name or IP",
+        default="localhost",
+    )  # type: ignore
+
+    pyarchinit_pg_port: IntProperty(
+        name="Port",
+        description="PostgreSQL server port",
+        default=5432,
+        min=1,
+        max=65535,
+    )  # type: ignore
+
+    pyarchinit_pg_dbname: StringProperty(
+        name="Database",
+        description="PostgreSQL database name",
+        default="",
+    )  # type: ignore
+
+    pyarchinit_pg_user: StringProperty(
+        name="User",
+        description="PostgreSQL user name",
+        default="",
+    )  # type: ignore
+
+    pyarchinit_pg_password: StringProperty(
+        name="Password",
+        description=(
+            "PostgreSQL password. Held only in memory for this session "
+            "(never saved in the .blend). Use 'Save to keychain' to "
+            "persist it securely in the OS keychain"
+        ),
+        subtype='PASSWORD',
+        options={'SKIP_SAVE'},
+        default="",
+    )  # type: ignore
+
     pyarchinit_table: EnumProperty(
         name="Table",
         items=[

--- a/em_setup/operators.py
+++ b/em_setup/operators.py
@@ -856,6 +856,60 @@ class EM_OT_open_license_url(Operator):
         return {'FINISHED'}
 
 
+class EM_OT_pyarchinit_pg_save_password(Operator):
+    """Store the PostgreSQL password in the OS keychain.
+
+    The password is never written into the .blend: it is saved in the
+    operating-system keychain (or, if that is unavailable, kept in
+    memory for this Blender session only). Issue #27, Sub-2.
+    """
+    bl_idname = "emtools.pyarchinit_pg_save_password"
+    bl_label = "Save PostgreSQL password to keychain"
+
+    def execute(self, context):
+        em_tools = context.scene.em_tools
+        host = (em_tools.pyarchinit_pg_host or "").strip()
+        dbname = (em_tools.pyarchinit_pg_dbname or "").strip()
+        user = (em_tools.pyarchinit_pg_user or "").strip()
+        port = em_tools.pyarchinit_pg_port
+        password = em_tools.pyarchinit_pg_password
+        if not (host and dbname and user):
+            self.report({'ERROR'}, "Fill host, database and user first.")
+            return {'CANCELLED'}
+        if not password:
+            self.report({'ERROR'}, "Type a password to save.")
+            return {'CANCELLED'}
+        from ..import_operators.pyarchinit_connection import set_password
+        tier = set_password(host, port, dbname, user, password)
+        if tier == "keychain":
+            self.report({'INFO'}, "Password saved to the OS keychain.")
+        else:
+            self.report(
+                {'WARNING'},
+                "OS keychain unavailable — password kept in memory for "
+                "this session only (still never written to the .blend).",
+            )
+        return {'FINISHED'}
+
+
+class EM_OT_pyarchinit_pg_forget_password(Operator):
+    """Remove the stored PostgreSQL password from keychain and memory."""
+    bl_idname = "emtools.pyarchinit_pg_forget_password"
+    bl_label = "Forget PostgreSQL password"
+
+    def execute(self, context):
+        em_tools = context.scene.em_tools
+        host = (em_tools.pyarchinit_pg_host or "").strip()
+        dbname = (em_tools.pyarchinit_pg_dbname or "").strip()
+        user = (em_tools.pyarchinit_pg_user or "").strip()
+        port = em_tools.pyarchinit_pg_port
+        from ..import_operators.pyarchinit_connection import forget_password
+        forget_password(host, port, dbname, user)
+        em_tools.pyarchinit_pg_password = ""
+        self.report({'INFO'}, "Password removed from keychain and memory.")
+        return {'FINISHED'}
+
+
 # Registration
 classes = (
     EM_create_collection,
@@ -873,6 +927,8 @@ classes = (
     AUXILIARY_OT_import_now,
     EM_OT_open_author_url,
     EM_OT_open_license_url,
+    EM_OT_pyarchinit_pg_save_password,
+    EM_OT_pyarchinit_pg_forget_password,
 )
 
 

--- a/em_setup/ui.py
+++ b/em_setup/ui.py
@@ -1388,7 +1388,23 @@ class EM_SetupPanel(bpy.types.Panel):
 
             elif em_tools.mode_3dgis_import_type == "pyarchinit":
                 options_box.label(text="pyArchInit Import Settings:")
-                options_box.prop(em_tools, "pyarchinit_db_path", text="SQLite Database")
+                options_box.prop(em_tools, "pyarchinit_connection_mode",
+                                 text="Connection", expand=True)
+                if em_tools.pyarchinit_connection_mode == "postgres":
+                    pg_box = options_box.box()
+                    pg_box.prop(em_tools, "pyarchinit_pg_host", text="Host")
+                    pg_box.prop(em_tools, "pyarchinit_pg_port", text="Port")
+                    pg_box.prop(em_tools, "pyarchinit_pg_dbname", text="Database")
+                    pg_box.prop(em_tools, "pyarchinit_pg_user", text="User")
+                    pg_box.prop(em_tools, "pyarchinit_pg_password", text="Password")
+                    creds = pg_box.row(align=True)
+                    creds.operator("emtools.pyarchinit_pg_save_password",
+                                   text="Save to keychain", icon='LOCKED')
+                    creds.operator("emtools.pyarchinit_pg_forget_password",
+                                   text="Forget", icon='UNLOCKED')
+                else:
+                    options_box.prop(em_tools, "pyarchinit_db_path",
+                                     text="SQLite Database")
                 options_box.prop(em_tools, "pyarchinit_mapping", text="Select Mapping")
                 options_box.operator("emtools.open_mapping_preferences",
                             text="",
@@ -1487,9 +1503,20 @@ class EM_SetupPanel(bpy.types.Panel):
                     em_tools.xlsx_id_column != "none"
                 )
             elif em_tools.mode_3dgis_import_type == "pyarchinit":
-                # Richiede: db path, mapping
+                # Richiede un mapping e una connessione valida: in SQLite
+                # il file DB, in PostgreSQL host+db+user (la password è
+                # verificata all'avvio dell'import, non qui — #27 Sub-2).
+                conn_mode = getattr(em_tools, "pyarchinit_connection_mode", "sqlite")
+                if conn_mode == "postgres":
+                    conn_ok = bool(
+                        (em_tools.pyarchinit_pg_host or "").strip() and
+                        (em_tools.pyarchinit_pg_dbname or "").strip() and
+                        (em_tools.pyarchinit_pg_user or "").strip()
+                    )
+                else:
+                    conn_ok = bool(em_tools.pyarchinit_db_path)
                 can_import = bool(
-                    em_tools.pyarchinit_db_path and
+                    conn_ok and
                     em_tools.pyarchinit_mapping != "none"
                 )
             elif em_tools.mode_3dgis_import_type == "emdb_xlsx":

--- a/export_manager/providers/__init__.py
+++ b/export_manager/providers/__init__.py
@@ -3,15 +3,18 @@
 from . import tabular
 from . import heriverse
 from . import rdf
+from . import pyarchinit
 
 
 def register():
     tabular.register()
     heriverse.register()
     rdf.register()
+    pyarchinit.register()
 
 
 def unregister():
+    pyarchinit.unregister()
     rdf.unregister()
     heriverse.unregister()
     tabular.unregister()

--- a/export_manager/providers/pyarchinit/__init__.py
+++ b/export_manager/providers/pyarchinit/__init__.py
@@ -1,0 +1,34 @@
+"""PyArchInit DB export provider: reverse-export the active EM graph
+back into a PyArchInit database via s3dgraphy.sync.GraphIngestor.
+
+Issue #27, Sub-3. Connection settings are shared with the 3D GIS import
+panel (Sub-2).
+"""
+
+from ...registry import ExportProvider, register_provider, unregister_provider
+from . import operators, ui
+
+
+PROVIDER = ExportProvider(
+    id="pyarchinit",
+    label="PyArchInit DB Export",
+    order=40,
+    icon='EXPORT',
+    poll=ui.poll,
+    draw=ui.draw,
+    help_title="PyArchInit DB Export",
+    help_text=("Write the active EM graph back into a PyArchInit database "
+               "(SQLite or PostgreSQL). Use 'Preview (dry run)' first to "
+               "see planned inserts/updates/conflicts."),
+    help_url="panels/export_manager.html#pyarchinit-db-export",
+)
+
+
+def register():
+    operators.register()
+    register_provider(PROVIDER)
+
+
+def unregister():
+    unregister_provider(PROVIDER.id)
+    operators.unregister()

--- a/export_manager/providers/pyarchinit/operators.py
+++ b/export_manager/providers/pyarchinit/operators.py
@@ -1,0 +1,172 @@
+"""'Export to PyArchInit DB' operator (issue #27, Sub-3).
+
+Writes the active s3dgraphy graph back into a PyArchInit database
+(SQLite or PostgreSQL) via ``s3dgraphy.sync.GraphIngestor``. A dry-run
+mode previews the planned inserts / updates / conflicts without
+touching the database.
+
+Connection settings are shared with the 3D GIS import panel (Sub-2):
+the same ``em_tools.pyarchinit_*`` fields and keychain are reused, so a
+round-trip reads and writes the same database with one configuration.
+"""
+
+import os
+
+import bpy  # type: ignore
+from bpy.props import BoolProperty  # type: ignore
+from bpy.types import Operator  # type: ignore
+
+
+class EXPORT_OT_pyarchinit_db(Operator):
+    """Write the active EM graph back into a PyArchInit database.
+
+    Toggle ``dry_run`` to preview the plan (no writes) versus applying
+    it. Uses the connection configured in the 3D GIS import panel.
+    """
+    bl_idname = "export.pyarchinit_db"
+    bl_label = "Export to PyArchInit DB"
+    bl_options = {"REGISTER"}
+
+    dry_run: BoolProperty(
+        name="Dry run",
+        description="Preview the planned changes without writing to the database",
+        default=True,
+        options={'SKIP_SAVE'},
+    )  # type: ignore
+
+    def execute(self, context):
+        em_tools = context.scene.em_tools
+        export_vars = context.window_manager.export_vars
+
+        # 1. Active graph -------------------------------------------------
+        if not (em_tools.active_file_index >= 0 and len(em_tools.graphml_files) > 0):
+            self.report({'ERROR'}, "No active graph to export.")
+            return {'CANCELLED'}
+        from s3dgraphy import get_graph
+        graphml = em_tools.graphml_files[em_tools.active_file_index]
+        graph = get_graph(graphml.name)
+        if graph is None:
+            self.report({'ERROR'},
+                        f"Active graph '{graphml.name}' is not loaded.")
+            return {'CANCELLED'}
+
+        # 2. Site name (required by GraphIngestor) ------------------------
+        sito = (getattr(export_vars, "pyarchinit_export_sito", "") or "").strip()
+        if not sito:
+            self.report({'ERROR'}, "Set the 'Site' name before exporting.")
+            return {'CANCELLED'}
+
+        # 3. Connection spec ---------------------------------------------
+        from ....import_operators.pyarchinit_connection import resolve_db_spec
+        from ....import_operators.pyarchinit_db_reader import (
+            is_postgres_spec, redacted_db_spec,
+        )
+        db_spec, err = resolve_db_spec(em_tools)
+        if err:
+            self.report({'ERROR'}, err)
+            return {'CANCELLED'}
+
+        # GraphIngestor resolves str specs through SQLAlchemy, so a SQLite
+        # *path* must become a sqlite:/// URL; a PG URL passes through.
+        if is_postgres_spec(db_spec):
+            sa_spec = db_spec
+        else:
+            sa_spec = "sqlite:///" + os.path.abspath(bpy.path.abspath(db_spec))
+
+        # 4. Ingestor -----------------------------------------------------
+        try:
+            from s3dgraphy.sync import GraphIngestor
+        except Exception as e:
+            self.report(
+                {'ERROR'},
+                f"s3dgraphy.sync is unavailable ({e}). The reverse-export "
+                "needs SQLAlchemy bundled — re-run './em.sh setup'.",
+            )
+            return {'CANCELLED'}
+
+        create_epochs = bool(
+            getattr(export_vars, "pyarchinit_export_create_epochs", False))
+
+        from .result_format import (
+            format_ingest_result, is_node_uuid_error, node_uuid_help,
+        )
+        from ....functions import show_popup_message
+
+        def _ingest():
+            return GraphIngestor().populate_list(
+                graph, sa_spec, sito,
+                dry_run=self.dry_run,
+                create_missing_epochs=create_epochs,
+            )
+
+        migration_note = None
+        try:
+            result = _ingest()
+        except Exception as e:
+            if not is_node_uuid_error(str(e)):
+                self.report({'ERROR'}, f"Export failed: {e}")
+                return {'CANCELLED'}
+
+            # node_uuid columns missing. NEVER mutate the schema during a
+            # dry-run preview — just explain. On a real export, try to add
+            # them (PyArchInit's job, attempted best-effort) and retry;
+            # fall back to the message if it can't.
+            if self.dry_run:
+                show_popup_message(
+                    context, title="PyArchInit DB needs updating",
+                    message=node_uuid_help(), icon='ERROR')
+                self.report(
+                    {'ERROR'},
+                    "PyArchInit DB missing node_uuid — update it from PyArchInit.")
+                return {'CANCELLED'}
+
+            from ....import_operators.pyarchinit_migrate import (
+                apply_node_uuid_migration,
+            )
+            try:
+                counts = apply_node_uuid_migration(sa_spec)
+            except Exception as me:
+                show_popup_message(
+                    context, title="PyArchInit DB needs updating",
+                    message=node_uuid_help(str(me)), icon='ERROR')
+                self.report(
+                    {'ERROR'},
+                    "Could not add node_uuid columns — update the DB from PyArchInit.")
+                return {'CANCELLED'}
+
+            migration_note = ("Added node_uuid columns: " +
+                              ", ".join(f"{t} (+{n})" for t, n in counts.items()))
+            try:
+                result = _ingest()
+            except Exception as e2:
+                self.report({'ERROR'}, f"Export failed after migration: {e2}")
+                return {'CANCELLED'}
+
+        # 5. Summary ------------------------------------------------------
+        lines = format_ingest_result(result, redacted_db_spec(db_spec), self.dry_run)
+        if migration_note:
+            lines.insert(1, migration_note)
+        show_popup_message(
+            context,
+            title=("PyArchInit DB — Dry run" if self.dry_run
+                   else "PyArchInit DB — Export"),
+            message="\n".join(lines),
+            icon='INFO',
+        )
+        self.report({'INFO'}, lines[0])
+        return {'FINISHED'}
+
+
+classes = (
+    EXPORT_OT_pyarchinit_db,
+)
+
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/export_manager/providers/pyarchinit/result_format.py
+++ b/export_manager/providers/pyarchinit/result_format.py
@@ -1,0 +1,76 @@
+"""Format a s3dgraphy.sync ``IngestResult`` into display lines.
+
+Blender-free so the formatter can be unit-tested with a duck-typed
+result object (issue #27, Sub-3).
+"""
+
+
+def is_node_uuid_error(message):
+    """True if ``message`` is GraphIngestor's missing-node_uuid error."""
+    return bool(message) and "node_uuid" in message
+
+
+def node_uuid_help(migration_failed=None):
+    """User-facing guidance for the missing-node_uuid case.
+
+    ``migration_failed`` (optional str) appends the reason EMTools could
+    not apply the migration automatically.
+    """
+    msg = (
+        "This PyArchInit database isn't ready for reverse-export yet.\n"
+        "\n"
+        "The 'node_uuid' columns are missing. They are normally added by "
+        "PyArchInit (it owns the database schema), on us_table, "
+        "inventario_materiali_table and periodizzazione_table.\n"
+        "\n"
+        "Update the database from PyArchInit and try again."
+    )
+    if migration_failed:
+        msg += (
+            "\n\nEMTools tried to add them automatically but could not: "
+            f"{migration_failed}"
+        )
+    return msg
+
+
+def format_ingest_result(result, target_label, dry_run):
+    """Return a list of human-readable summary lines for ``result``.
+
+    ``result`` is a s3dgraphy.sync.IngestResult (or anything exposing the
+    same attributes). ``target_label`` is the credential-stripped DB
+    spec. ``dry_run`` toggles the heading between a preview and a real
+    write.
+    """
+    head = ("DRY-RUN — nothing was written"
+            if dry_run else "Export complete — changes written")
+    lines = [
+        head,
+        f"Target:    {target_label}",
+        f"Applied:   {getattr(result, 'applied', 0)}",
+        f"Inserted:  {getattr(result, 'inserted', 0)}",
+        f"Updated:   {getattr(result, 'updated', 0)}",
+        f"Skipped:   {getattr(result, 'skipped', 0)}",
+        f"Epochs +:  {getattr(result, 'epochs_created', 0)}",
+    ]
+
+    conflicts = tuple(getattr(result, "conflicts", ()) or ())
+    if conflicts:
+        lines.append(f"Conflicts: {len(conflicts)}")
+        for c in conflicts[:5]:
+            lines.append(
+                f"  - {getattr(c, 'field', '?')} "
+                f"@ {getattr(c, 'node_uuid', '?')}: "
+                f"{getattr(c, 'db_value', '?')} -> {getattr(c, 'graph_value', '?')}"
+            )
+        if len(conflicts) > 5:
+            lines.append(f"  … and {len(conflicts) - 5} more")
+
+    errors = tuple(getattr(result, "errors", ()) or ())
+    if errors:
+        lines.append(f"Errors:    {len(errors)}")
+        for e in errors[:5]:
+            lines.append(f"  - {e}")
+        if len(errors) > 5:
+            lines.append(f"  … and {len(errors) - 5} more")
+
+    return lines

--- a/export_manager/providers/pyarchinit/ui.py
+++ b/export_manager/providers/pyarchinit/ui.py
@@ -1,0 +1,41 @@
+# export_manager/providers/pyarchinit/ui.py
+"""Draw function for the 'PyArchInit DB' section of the Export panel (#27)."""
+
+
+def poll(context):
+    return True
+
+
+def draw(box, context):
+    em_tools = context.scene.em_tools
+    export_vars = context.window_manager.export_vars
+
+    # The export reuses the connection configured in the 3D GIS import
+    # panel (Sub-2) — show which target it will write to.
+    conn_mode = getattr(em_tools, "pyarchinit_connection_mode", "sqlite")
+    info = box.row()
+    if conn_mode == "postgres":
+        host = (getattr(em_tools, "pyarchinit_pg_host", "") or "").strip()
+        dbname = (getattr(em_tools, "pyarchinit_pg_dbname", "") or "").strip()
+        target = f"PostgreSQL: {host}/{dbname}" if (host and dbname) else "PostgreSQL (not configured)"
+    else:
+        path = getattr(em_tools, "pyarchinit_db_path", "")
+        target = f"SQLite: {path}" if path else "SQLite (no file selected)"
+    info.label(text=target, icon='EXPORT')
+
+    box.label(text="Connection is set in the 3D GIS Import panel.", icon='INFO')
+
+    box.prop(export_vars, "pyarchinit_export_sito", text="Site")
+    box.prop(export_vars, "pyarchinit_export_create_epochs")
+
+    col = box.column(align=True)
+    preview = col.row()
+    op = preview.operator("export.pyarchinit_db",
+                          text="Preview (dry run)", icon='VIEWZOOM')
+    op.dry_run = True
+
+    write = col.row()
+    write.scale_y = 1.3
+    op = write.operator("export.pyarchinit_db",
+                        text="Export to PyArchInit DB", icon='EXPORT')
+    op.dry_run = False

--- a/import_operators/import_EMdb.py
+++ b/import_operators/import_EMdb.py
@@ -123,32 +123,11 @@ class EM_OT_import_3dgis_database(bpy.types.Operator):
 
         The password is read from the (SKIP_SAVE) password field if the
         user just typed it, otherwise from the OS keychain — never from
-        the .blend (issue #27).
+        the .blend (issue #27). Delegates to the shared resolver so the
+        import and export paths stay in sync.
         """
-        mode = getattr(em_tools, "pyarchinit_connection_mode", "sqlite")
-        if mode == "postgres":
-            from .pyarchinit_connection import build_connection_url, get_password
-            host = (em_tools.pyarchinit_pg_host or "").strip()
-            port = em_tools.pyarchinit_pg_port
-            dbname = (em_tools.pyarchinit_pg_dbname or "").strip()
-            user = (em_tools.pyarchinit_pg_user or "").strip()
-            if not (host and dbname and user):
-                return None, ("PostgreSQL connection needs host, database "
-                              "and user. Fill them in the 3D GIS import panel.")
-            password = em_tools.pyarchinit_pg_password or get_password(
-                host, port, dbname, user)
-            if not password:
-                return None, ("No PostgreSQL password set. Type it in the "
-                              "panel (and optionally 'Save to keychain').")
-            url = build_connection_url(host, port, dbname, user, password)
-            return url, None
-
-        # Default: SQLite. Keep the raw path (PyArchInitImporter and the
-        # geometry reader resolve it themselves) — behaviour unchanged.
-        path = em_tools.pyarchinit_db_path
-        if not path:
-            return None, "Select a pyArchInit SQLite database file."
-        return path, None
+        from .pyarchinit_connection import resolve_db_spec
+        return resolve_db_spec(em_tools)
 
     def _collect_pyarchinit_filters(self, em_tools):
         """Collect the user-selected filter values into a dict.

--- a/import_operators/import_EMdb.py
+++ b/import_operators/import_EMdb.py
@@ -68,12 +68,22 @@ class EM_OT_import_3dgis_database(bpy.types.Operator):
             import_type = em_tools.mode_3dgis_import_type
             
             if import_type == "pyarchinit":
+                from .pyarchinit_db_reader import is_postgres_spec
+                db_spec, err = self._resolve_pyarchinit_db_spec(em_tools)
+                if err:
+                    self.report({'ERROR'}, err)
+                    return None
                 settings = {
                     'import_type': import_type,
-                    'filepath': em_tools.pyarchinit_db_path,
                     'mapping_name': em_tools.pyarchinit_mapping,
                     'mode': '3DGIS'
                 }
+                # SQLite path vs PostgreSQL URL — mutually exclusive
+                # kwargs on PyArchInitImporter (issue #27, Sub-2).
+                if is_postgres_spec(db_spec):
+                    settings['connection_url'] = db_spec
+                else:
+                    settings['filepath'] = db_spec
                 filters = self._collect_pyarchinit_filters(em_tools)
                 if filters is None:
                     # Required filter left at "(All values)" — abort
@@ -99,6 +109,46 @@ class EM_OT_import_3dgis_database(bpy.types.Operator):
                     'mapping_name': em_tools.emdb_mapping,
                     'mode': '3DGIS'
                 }
+
+    def _resolve_pyarchinit_db_spec(self, em_tools):
+        """Resolve the pyArchInit connection spec from the 3D GIS panel.
+
+        Returns ``(db_spec, error)``:
+
+        * ``db_spec`` — a SQLite file path (SQLite mode) or a
+          ``postgresql+psycopg2://…`` URL (PostgreSQL mode), suitable
+          for both PyArchInitImporter and the geometry reader.
+        * ``error`` — None on success, or a user-facing message when the
+          chosen mode is missing required fields.
+
+        The password is read from the (SKIP_SAVE) password field if the
+        user just typed it, otherwise from the OS keychain — never from
+        the .blend (issue #27).
+        """
+        mode = getattr(em_tools, "pyarchinit_connection_mode", "sqlite")
+        if mode == "postgres":
+            from .pyarchinit_connection import build_connection_url, get_password
+            host = (em_tools.pyarchinit_pg_host or "").strip()
+            port = em_tools.pyarchinit_pg_port
+            dbname = (em_tools.pyarchinit_pg_dbname or "").strip()
+            user = (em_tools.pyarchinit_pg_user or "").strip()
+            if not (host and dbname and user):
+                return None, ("PostgreSQL connection needs host, database "
+                              "and user. Fill them in the 3D GIS import panel.")
+            password = em_tools.pyarchinit_pg_password or get_password(
+                host, port, dbname, user)
+            if not password:
+                return None, ("No PostgreSQL password set. Type it in the "
+                              "panel (and optionally 'Save to keychain').")
+            url = build_connection_url(host, port, dbname, user, password)
+            return url, None
+
+        # Default: SQLite. Keep the raw path (PyArchInitImporter and the
+        # geometry reader resolve it themselves) — behaviour unchanged.
+        path = em_tools.pyarchinit_db_path
+        if not path:
+            return None, "Select a pyArchInit SQLite database file."
+        return path, None
 
     def _collect_pyarchinit_filters(self, em_tools):
         """Collect the user-selected filter values into a dict.
@@ -320,8 +370,15 @@ class EM_OT_import_3dgis_database(bpy.types.Operator):
         """Set metadata on the graph after import"""
         if not hasattr(graph, 'attributes'):
             graph.attributes = {}
-        
-        graph.attributes['source_file'] = str(settings['filepath'])
+
+        # 3D GIS pyArchInit may carry a connection_url instead of a
+        # filepath; redact credentials before recording provenance so a
+        # PostgreSQL password never lands in the graph / .blend (#27).
+        source = settings.get('filepath')
+        if source is None and settings.get('connection_url'):
+            from .pyarchinit_db_reader import redacted_db_spec
+            source = redacted_db_spec(settings['connection_url'])
+        graph.attributes['source_file'] = str(source or '')
         graph.attributes['import_type'] = settings['import_type']
         
         print(f"EM-tools: Set metadata on graph '{graph.graph_id}'")
@@ -354,7 +411,12 @@ class EM_OT_import_3dgis_database(bpy.types.Operator):
         else:
             if not em_tools.pyarchinit_import_geometries:
                 return
-            db_path = em_tools.pyarchinit_db_path
+            db_path, err = self._resolve_pyarchinit_db_spec(em_tools)
+            if err:
+                from ..functions import show_popup_message
+                show_popup_message(context, title="Geometry import ERROR",
+                                   message=err, icon='ERROR')
+                return
             force_update = em_tools.pyarchinit_geom_force_update
             graph_code = "GraphMain"
 

--- a/import_operators/import_validator.py
+++ b/import_operators/import_validator.py
@@ -28,7 +28,10 @@ class ImportValidator:
         },
 
         'pyarchinit': {
-            'required_fields': ['filepath', 'mapping_name'],
+            # Either a SQLite ``filepath`` OR a PostgreSQL ``connection_url``
+            # is accepted (issue #27, Sub-2) — see ``required_one_of``.
+            'required_fields': ['mapping_name'],
+            'required_one_of': ['filepath', 'connection_url'],
             'mapping_required': True,
             'file_extensions': ['.sqlite', '.db', '.sql']
         }
@@ -63,6 +66,12 @@ class ImportValidator:
         for field in rules['required_fields']:
             if not settings.get(field):
                 return False, f"Missing required field: {field}"
+
+        # Check "one of" requirement (e.g. SQLite filepath OR PG
+        # connection_url for pyArchInit — exactly one connection source).
+        one_of = rules.get('required_one_of')
+        if one_of and not any(settings.get(f) for f in one_of):
+            return False, f"Provide one of: {', '.join(one_of)}"
 
         # Check mapping if required
         if rules['mapping_required']:

--- a/import_operators/importer_registry.py
+++ b/import_operators/importer_registry.py
@@ -77,10 +77,15 @@ IMPORTER_REGISTRY = {
         optional_params=[]
     ),
 
+    # pyArchInit accepts EITHER a SQLite ``filepath`` OR a PostgreSQL
+    # ``connection_url`` (mutually exclusive — PyArchInitImporter raises
+    # if both/neither are given). Both are declared optional here; the
+    # operator (import_EMdb.get_import_settings) guarantees exactly one
+    # is set per the user's chosen connection mode (issue #27, Sub-2).
     'pyarchinit': ImporterConfig(
         importer_class=PyArchInitImporter,
-        required_params=['filepath', 'mapping_name'],
-        optional_params=['filters']
+        required_params=['mapping_name'],
+        optional_params=['filepath', 'connection_url', 'filters']
     ),
 
     # ✅ EXTENSIBILITY: Adding new formats is easy - just add entry here:

--- a/import_operators/pyarchinit_connection.py
+++ b/import_operators/pyarchinit_connection.py
@@ -100,6 +100,45 @@ def forget_password(host, port, dbname, user):
             pass
 
 
+def resolve_db_spec(em_tools):
+    """Resolve a pyArchInit connection spec from the shared em_tools fields.
+
+    Reads the same connection properties used by the 3D GIS import panel
+    (``pyarchinit_connection_mode`` + SQLite path or PostgreSQL fields)
+    so import and export (Sub-2 / Sub-3) share one connection config.
+
+    Returns ``(db_spec, error)``:
+
+    * ``db_spec`` — a SQLite file path (SQLite mode) or a
+      ``postgresql+psycopg2://…`` URL (PostgreSQL mode).
+    * ``error`` — None on success, or a user-facing message when the
+      chosen mode is missing required fields.
+
+    Blender-free: ``em_tools`` is read purely via ``getattr`` so this
+    stays unit-testable with a plain object.
+    """
+    mode = getattr(em_tools, "pyarchinit_connection_mode", "sqlite")
+    if mode == "postgres":
+        host = (getattr(em_tools, "pyarchinit_pg_host", "") or "").strip()
+        port = getattr(em_tools, "pyarchinit_pg_port", 5432)
+        dbname = (getattr(em_tools, "pyarchinit_pg_dbname", "") or "").strip()
+        user = (getattr(em_tools, "pyarchinit_pg_user", "") or "").strip()
+        if not (host and dbname and user):
+            return None, ("PostgreSQL connection needs host, database and "
+                          "user. Fill them in the 3D GIS import panel.")
+        password = getattr(em_tools, "pyarchinit_pg_password", "") or \
+            get_password(host, port, dbname, user)
+        if not password:
+            return None, ("No PostgreSQL password set. Type it in the 3D GIS "
+                          "panel (and optionally 'Save to keychain').")
+        return build_connection_url(host, port, dbname, user, password), None
+
+    path = getattr(em_tools, "pyarchinit_db_path", "")
+    if not path:
+        return None, "Select a pyArchInit SQLite database file."
+    return path, None
+
+
 def build_connection_url(host, port, dbname, user, password):
     """Build a psycopg2/SQLAlchemy URL with URL-encoded credentials.
 

--- a/import_operators/pyarchinit_connection.py
+++ b/import_operators/pyarchinit_connection.py
@@ -1,0 +1,122 @@
+"""Build PyArchInit PostgreSQL connection specs and keep credentials
+out of the .blend (issue #27, Sub-2).
+
+The password is **never** persisted in the .blend. Two storage tiers,
+in order of preference:
+
+1. **OS keychain** via the optional ``keyring`` library — macOS
+   Keychain, Windows Credential Locker, or the Linux Secret Service.
+2. **Session memory** fallback — a process-local dict discarded when
+   Blender quits. Used when ``keyring`` (or its platform backend) is
+   unavailable, so the feature still works without ever touching disk.
+
+The Blender ``StringProperty`` that backs the password field is
+declared with ``options={'SKIP_SAVE'}`` (see ``em_props.py``), so even
+the transient typed value is excluded from the saved file.
+
+This module is import-safe outside Blender (no ``bpy`` import) so the
+URL builder, redaction, and account-id logic stay unit-testable.
+"""
+
+from urllib.parse import quote
+
+# Keychain service name (the "where" namespace under which all EMTools
+# PyArchInit credentials are filed in the OS keychain).
+KEYRING_SERVICE = "emtools-pyarchinit"
+
+# Session-only fallback store: account_id -> password. Lives for the
+# lifetime of the Blender process and is never written anywhere.
+_MEMORY_FALLBACK = {}
+
+
+def _keyring():
+    """Return the ``keyring`` module, or None if unavailable.
+
+    Importing keyring can fail (not bundled) and, even when importable,
+    a usable backend may be missing (typical on headless Linux). Both
+    cases return None so callers fall back to session memory.
+    """
+    try:
+        import keyring
+        from keyring.errors import NoKeyringError
+        try:
+            # Probe for a working backend without raising on the caller.
+            backend = keyring.get_keyring()
+            if backend is None:
+                return None
+        except NoKeyringError:
+            return None
+        return keyring
+    except Exception:
+        return None
+
+
+def account_id(host, port, dbname, user):
+    """Stable keychain account label for a connection's credentials."""
+    return f"{user}@{host}:{port}/{dbname}"
+
+
+def set_password(host, port, dbname, user, password):
+    """Persist ``password`` for the connection.
+
+    Returns the tier actually used: ``"keychain"`` or ``"memory"``.
+    """
+    acct = account_id(host, port, dbname, user)
+    kr = _keyring()
+    if kr is not None:
+        try:
+            kr.set_password(KEYRING_SERVICE, acct, password)
+            _MEMORY_FALLBACK.pop(acct, None)
+            return "keychain"
+        except Exception:
+            pass
+    _MEMORY_FALLBACK[acct] = password
+    return "memory"
+
+
+def get_password(host, port, dbname, user):
+    """Return the stored password (keychain first, then memory), or None."""
+    acct = account_id(host, port, dbname, user)
+    kr = _keyring()
+    if kr is not None:
+        try:
+            pw = kr.get_password(KEYRING_SERVICE, acct)
+            if pw is not None:
+                return pw
+        except Exception:
+            pass
+    return _MEMORY_FALLBACK.get(acct)
+
+
+def forget_password(host, port, dbname, user):
+    """Remove the stored password from both keychain and memory."""
+    acct = account_id(host, port, dbname, user)
+    _MEMORY_FALLBACK.pop(acct, None)
+    kr = _keyring()
+    if kr is not None:
+        try:
+            kr.delete_password(KEYRING_SERVICE, acct)
+        except Exception:
+            pass
+
+
+def build_connection_url(host, port, dbname, user, password):
+    """Build a psycopg2/SQLAlchemy URL with URL-encoded credentials.
+
+    ``postgresql+psycopg2://<user>:<password>@<host>:<port>/<dbname>``
+
+    User and password are percent-encoded so that ``@``, ``:``, ``/``
+    and other reserved characters in a password don't corrupt the URL.
+    A falsy ``password`` produces a URL with no password component
+    (libpq may then read ``~/.pgpass`` or prompt — handled upstream).
+    """
+    userinfo = quote(str(user or ""), safe="")
+    if password:
+        userinfo += ":" + quote(str(password), safe="")
+    host_port = host or "localhost"
+    if port:
+        host_port += f":{int(port)}"
+    return (
+        f"postgresql+psycopg2://{userinfo}@{host_port}"
+        f"/{quote(str(dbname or ''), safe='')}"
+    )

--- a/import_operators/pyarchinit_db_reader.py
+++ b/import_operators/pyarchinit_db_reader.py
@@ -1,8 +1,24 @@
-"""Read pyunitastratigrafiche rows from a PyArchInit SQLite database.
+"""Read pyunitastratigrafiche rows from a PyArchInit database.
 
 Handles schema detection (table presence, geometry column name, SRID)
 and yields well-formed dicts ready for the WKB parser. Stays
 Blender-free for easy testing.
+
+Two backends are supported (issue #27, Sub-2):
+
+* **SQLite / SpatiaLite** — the original path. The geometry column is
+  read as a native BLOB and handed to ``wkb_parser`` directly.
+* **PostgreSQL / PostGIS** — selected when the caller passes a
+  ``postgresql://…`` / ``postgresql+psycopg2://…`` connection URL.
+  The geometry is fetched as standard WKB via ``ST_AsBinary(<geom>)``
+  so the very same ``wkb_parser`` works unchanged. Requires
+  ``psycopg2`` (bundled as ``psycopg2-binary``).
+
+The module-level ``open_readonly`` / ``detect_geometry_column`` /
+``detect_key_columns`` / ``fetch_polygons`` helpers remain SQLite-only
+and parameterised with ``?`` placeholders (their behaviour is frozen
+for the existing test-suite). Backend-agnostic callers should use
+:class:`PyArchInitReader`, which dispatches on the connection spec.
 """
 
 import sqlite3
@@ -170,3 +186,274 @@ def fetch_polygons(conn, geom_column, filters=None):
             "wkb": wkb,
             "wkb_hex_preview": wkb[:16].hex(),
         }
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL / PostGIS backend (issue #27, Sub-2)
+#
+# Mirrors the SQLite helpers above but talks to PostGIS through psycopg2.
+# The only material difference is that the geometry column is read with
+# ``ST_AsBinary(<geom>)`` so the bytes on the wire are standard WKB —
+# exactly what ``wkb_parser`` already understands. psycopg2 uses ``%s``
+# placeholders (not ``?``), so the filter clause is rebuilt accordingly.
+# ---------------------------------------------------------------------------
+
+PG_URL_PREFIXES = (
+    "postgresql://",
+    "postgresql+psycopg2://",
+    "postgres://",
+)
+
+
+def is_postgres_spec(db_spec):
+    """Return True if ``db_spec`` is a PostgreSQL connection URL.
+
+    Anything else (a filesystem path, ``sqlite:///…``) is treated as the
+    SQLite/SpatiaLite path by the dispatcher.
+    """
+    return isinstance(db_spec, str) and db_spec.startswith(PG_URL_PREFIXES)
+
+
+def redacted_db_spec(db_spec):
+    """Return a copy of ``db_spec`` safe to persist as provenance.
+
+    For a PostgreSQL URL the ``user:password@`` userinfo is stripped so
+    the password is never written into the .blend (issue #27 explicitly
+    forbids storing DB passwords there). SQLite paths are returned
+    unchanged.
+
+    ``postgresql://user:secret@host:5432/db`` → ``postgresql://host:5432/db``
+    """
+    if not is_postgres_spec(db_spec):
+        return db_spec
+    scheme, sep, rest = db_spec.partition("://")
+    if not sep:
+        return db_spec
+    # rest = [userinfo@]host[:port]/db... — drop everything up to '@'.
+    host_part = rest.split("@", 1)[1] if "@" in rest else rest
+    return f"{scheme}://{host_part}"
+
+
+def _normalise_pg_dsn(url):
+    """Strip the SQLAlchemy ``+psycopg2`` driver tag psycopg2 can't parse.
+
+    ``postgresql+psycopg2://u:p@h/db`` → ``postgresql://u:p@h/db``.
+    A bare ``postgres://`` is left untouched (libpq accepts it).
+    """
+    if url.startswith("postgresql+psycopg2://"):
+        return "postgresql://" + url[len("postgresql+psycopg2://"):]
+    return url
+
+
+def open_pg_readonly(url):
+    """Open a read-only psycopg2 connection from a connection URL.
+
+    Raises :class:`PyArchInitDBError` (never leaks the password-bearing
+    DSN in the message) when psycopg2 is missing or the connection
+    fails.
+    """
+    try:
+        import psycopg2  # noqa: F401  (bundled as psycopg2-binary)
+    except ImportError as exc:
+        raise PyArchInitDBError(
+            "PostgreSQL import requires the 'psycopg2' driver, which is "
+            "not available in this Blender build. Re-run './em.sh setup' "
+            "to refresh the bundled wheels."
+        ) from exc
+    try:
+        conn = psycopg2.connect(_normalise_pg_dsn(url))
+        # Read-only + autocommit: we never write on the import path.
+        conn.set_session(readonly=True, autocommit=True)
+        return conn
+    except Exception as exc:  # psycopg2.OperationalError et al.
+        # Deliberately do NOT echo ``url`` — it embeds the password.
+        raise PyArchInitDBError(
+            f"could not connect to PostgreSQL database: {exc}"
+        ) from exc
+
+
+def _pg_columns(conn, table=TABLE_NAME):
+    """Return the set of column names of ``table`` (empty if absent)."""
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_name = %s",
+        (table,),
+    )
+    return {r[0] for r in cur.fetchall()}
+
+
+def pg_table_exists(conn, name=TABLE_NAME):
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT 1 FROM information_schema.tables "
+        "WHERE table_name = %s LIMIT 1",
+        (name,),
+    )
+    return cur.fetchone() is not None
+
+
+def detect_geometry_column_pg(conn):
+    """Return (geom_column_name, srid) for the PostGIS spatial table.
+
+    Prefers the PostGIS ``geometry_columns`` view (authoritative SRID);
+    falls back to ``information_schema`` column probing with srid 0.
+    """
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT f_geometry_column, srid FROM geometry_columns "
+            "WHERE f_table_name = %s",
+            (TABLE_NAME,),
+        )
+        row = cur.fetchone()
+        if row:
+            return row[0], int(row[1] or 0)
+    except Exception:
+        # geometry_columns missing (PostGIS not installed) — fall back.
+        pass
+    cols = _pg_columns(conn)
+    for cand in GEOM_COLUMN_FALLBACKS:
+        if cand in cols:
+            return cand, 0
+    raise PyArchInitDBError(
+        f"could not locate a geometry column in '{TABLE_NAME}'"
+    )
+
+
+def detect_key_columns_pg(conn):
+    """PostgreSQL twin of :func:`detect_key_columns`."""
+    cols = _pg_columns(conn)
+    us_col = next((c for c in US_COLUMN_FALLBACKS if c in cols), None)
+    area_col = next((c for c in AREA_COLUMN_FALLBACKS if c in cols), None)
+    sito_col = next((c for c in SITO_COLUMN_FALLBACKS if c in cols), None)
+    missing = [n for n, v in (("us", us_col), ("area", area_col),
+                              ("sito/scavo", sito_col)) if v is None]
+    if missing:
+        raise PyArchInitDBError(
+            f"missing key columns in '{TABLE_NAME}': {', '.join(missing)}"
+        )
+    return us_col, area_col, sito_col
+
+
+def _build_filter_clause_pg(filters, us_col, area_col, sito_col):
+    """``_build_filter_clause`` with ``%s`` placeholders for psycopg2.
+
+    Same whitelist / alias translation / silent-skip semantics; only the
+    placeholder style differs. Values stay parameterised — never
+    interpolated — so the SQL-injection guard is identical.
+    """
+    if not filters:
+        return "", []
+
+    semantic_to_actual = {
+        "us": us_col,
+        "area": area_col,
+        "sito": sito_col,
+    }
+    clauses = []
+    params = []
+    for raw_col, value in filters.items():
+        if not isinstance(raw_col, str):
+            continue
+        semantic = _FILTER_ALIASES.get(raw_col.strip().lower())
+        if semantic is None:
+            continue
+        actual_col = semantic_to_actual.get(semantic)
+        if not actual_col:
+            continue
+        clauses.append(f"{actual_col} = %s")
+        params.append(value)
+
+    if not clauses:
+        return "", []
+    return " WHERE " + " AND ".join(clauses), params
+
+
+def fetch_polygons_pg(conn, geom_column, filters=None):
+    """PostgreSQL twin of :func:`fetch_polygons`.
+
+    Geometry is fetched as WKB via ``ST_AsBinary`` so the shared
+    ``wkb_parser`` handles it unchanged.
+    """
+    us_col, area_col, sito_col = detect_key_columns_pg(conn)
+    where_sql, params = _build_filter_clause_pg(
+        filters, us_col, area_col, sito_col
+    )
+    cur = conn.cursor()
+    cur.execute(
+        f"SELECT {us_col}, {area_col}, {sito_col}, "
+        f"ST_AsBinary({geom_column}) "
+        f"FROM {TABLE_NAME}{where_sql}",
+        params,
+    )
+    for us, area, sito, geom in cur:
+        if geom is None:
+            continue
+        wkb = bytes(geom)
+        yield {
+            "us": us,
+            "area": area,
+            "sito": sito,
+            "us_key": f"sito={sito},area={area},us={us}",
+            "wkb": wkb,
+            "wkb_hex_preview": wkb[:16].hex(),
+        }
+
+
+class PyArchInitReader:
+    """Backend-agnostic reader for the ``pyunitastratigrafiche`` table.
+
+    Pass either a SQLite/SpatiaLite file path or a PostgreSQL connection
+    URL (``postgresql://…``); the reader dispatches to the matching
+    backend and exposes one uniform interface to the geometry importer.
+    Blender-free. Usable as a context manager::
+
+        with PyArchInitReader(db_spec) as reader:
+            if reader.table_exists():
+                geom_col, srid = reader.detect_geometry_column()
+                for row in reader.fetch_polygons(filters):
+                    ...
+    """
+
+    def __init__(self, db_spec):
+        self.db_spec = db_spec
+        self.is_postgres = is_postgres_spec(db_spec)
+        if self.is_postgres:
+            self._conn = open_pg_readonly(db_spec)
+        else:
+            self._conn = open_readonly(db_spec)
+        self._geom_col = None
+        self._srid = None
+
+    def table_exists(self):
+        if self.is_postgres:
+            return pg_table_exists(self._conn)
+        return table_exists(self._conn)
+
+    def detect_geometry_column(self):
+        if self.is_postgres:
+            self._geom_col, self._srid = detect_geometry_column_pg(self._conn)
+        else:
+            self._geom_col, self._srid = detect_geometry_column(self._conn)
+        return self._geom_col, self._srid
+
+    def fetch_polygons(self, filters=None):
+        if self._geom_col is None:
+            self.detect_geometry_column()
+        if self.is_postgres:
+            yield from fetch_polygons_pg(self._conn, self._geom_col, filters)
+        else:
+            yield from fetch_polygons(self._conn, self._geom_col, filters)
+
+    def close(self):
+        try:
+            self._conn.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()

--- a/import_operators/pyarchinit_geom_importer.py
+++ b/import_operators/pyarchinit_geom_importer.py
@@ -10,10 +10,8 @@ import bpy  # type: ignore
 
 from . import geom_constants as C
 from .pyarchinit_db_reader import (
-    open_readonly,
-    table_exists,
-    detect_geometry_column,
-    fetch_polygons,
+    PyArchInitReader,
+    redacted_db_spec,
     PyArchInitDBError,
     TABLE_NAME,
 )
@@ -57,28 +55,33 @@ def import_geometries(context, db_path, graph, graph_code, force_update,
         "warnings": [],
     }
 
+    # Credential-stripped spec used for any persisted provenance / error
+    # text. For a PostgreSQL URL this drops ``user:password@`` so the
+    # password never reaches a custom property or a popup (issue #27).
+    safe_spec = redacted_db_spec(db_path)
+
     try:
-        conn = open_readonly(db_path)
+        reader = PyArchInitReader(db_path)
     except Exception as e:
-        show_warning_callback("ERROR", f"Cannot open DB: {db_path}\n{e}")
+        show_warning_callback("ERROR", f"Cannot open DB: {safe_spec}\n{e}")
         return report
 
     try:
-        if not table_exists(conn):
+        if not reader.table_exists():
             show_warning_callback(
                 "WARNING",
                 f"Table '{TABLE_NAME}' not present in DB — no geometries to import.",
             )
             return report
         try:
-            geom_col, srid = detect_geometry_column(conn)
+            geom_col, srid = reader.detect_geometry_column()
         except PyArchInitDBError as e:
             show_warning_callback("ERROR", str(e))
             return report
 
         polygons = []
         try:
-            for row in fetch_polygons(conn, geom_col, filters=filters):
+            for row in reader.fetch_polygons(filters=filters):
                 try:
                     row["parsed_rings"] = parse_wkb(row["wkb"])
                     polygons.append(row)
@@ -116,7 +119,7 @@ def import_geometries(context, db_path, graph, graph_code, force_update,
         graph_coll = ensure_collection(graph_code, parent=parent_coll)
 
         for entry in plan["create"]:
-            obj = _create_one(entry, graph_coll, shift_xyz, db_path,
+            obj = _create_one(entry, graph_coll, shift_xyz, safe_spec,
                               graph_code, context=context, graph=graph)
             _link_to_node(entry["node"], obj)
             report["created"] += 1
@@ -147,10 +150,10 @@ def import_geometries(context, db_path, graph, graph_code, force_update,
                 move_obj_to_collection(obj, orphan_coll)
             report["marked_orphan_obj"] = len(plan["mark_orphan_obj"])
 
-        _handle_polygon_orphans(polygons, graph, shift_xyz, db_path, report)
+        _handle_polygon_orphans(polygons, graph, shift_xyz, safe_spec, report)
         _record_us_without_geometry(polygons, graph, report)
     finally:
-        conn.close()
+        reader.close()
 
     return report
 

--- a/import_operators/pyarchinit_migrate.py
+++ b/import_operators/pyarchinit_migrate.py
@@ -1,0 +1,110 @@
+"""Best-effort PyArchInit ``node_uuid`` migration from EMTools (#27, Sub-3).
+
+``s3dgraphy.sync.GraphIngestor`` requires a ``node_uuid`` column on the
+PyArchInit tables (``us_table``, ``inventario_materiali_table``,
+``periodizzazione_table``). That column is normally added by a
+PyArchInit-side production migration — PyArchInit owns the DB schema.
+
+When exporting to a database that hasn't been migrated yet, EMTools
+attempts to apply the same change (add the column + a partial unique
+index, then backfill unique ids). If it can't (e.g. missing DDL
+privileges, no primary key on PostgreSQL), the caller falls back to a
+clear message telling the user to update the database from PyArchInit.
+
+Backend-agnostic via SQLAlchemy (SQLite + PostgreSQL). Blender-free.
+This mirrors the logic of s3dgraphy's test-only ``_uuid_backfill``
+helper but uses only SQLAlchemy so it carries no s3dgraphy-internal
+imports.
+"""
+
+import uuid as _uuid
+
+
+#: Tables that need a stable node identity for the s3dgraphy bridge.
+TABLES = (
+    "us_table",
+    "inventario_materiali_table",
+    "periodizzazione_table",
+)
+
+#: Canonical primary-key column per table (fallback for legacy PG dumps
+#: that declare no PRIMARY KEY).
+_CANONICAL_PK = {
+    "us_table": "id_us",
+    "inventario_materiali_table": "id_invmat",
+    "periodizzazione_table": "id_perfas",
+}
+
+
+def _new_uuid():
+    """A unique id string. Prefer s3dgraphy's uuid7 (time-ordered) when
+    present, else fall back to uuid4 — the column only needs uniqueness."""
+    try:
+        from s3dgraphy.sync.uuid7 import uuid7
+        return str(uuid7())
+    except Exception:
+        return str(_uuid.uuid4())
+
+
+def apply_node_uuid_migration(sa_spec):
+    """Add ``node_uuid`` columns + indexes and backfill them.
+
+    ``sa_spec`` is a SQLAlchemy URL (``sqlite:///…`` or
+    ``postgresql+psycopg2://…``). Only tables that actually exist are
+    touched. Returns ``{table: backfilled_row_count}`` for the tables
+    present. Raises on any failure so the caller can fall back to a
+    user-facing message.
+    """
+    from sqlalchemy import create_engine, inspect, text
+
+    engine = create_engine(sa_spec)
+    insp = inspect(engine)
+    existing = set(insp.get_table_names())
+    targets = [t for t in TABLES if t in existing]
+    if not targets:
+        raise RuntimeError(
+            "none of the PyArchInit tables (us_table, "
+            "inventario_materiali_table, periodizzazione_table) were found"
+        )
+    is_pg = engine.dialect.name == "postgresql"
+
+    # 1. Add column + partial unique index (idempotent).
+    with engine.begin() as conn:
+        for table in targets:
+            cols = {c["name"] for c in insp.get_columns(table)}
+            if "node_uuid" not in cols:
+                conn.execute(
+                    text(f"ALTER TABLE {table} ADD COLUMN node_uuid TEXT"))
+            conn.execute(text(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS ix_{table}_node_uuid "
+                f"ON {table}(node_uuid) WHERE node_uuid IS NOT NULL"))
+
+    # 2. Backfill NULL node_uuid values.
+    insp = inspect(engine)  # refresh after DDL
+    counts = {}
+    with engine.begin() as conn:
+        for table in targets:
+            pks = insp.get_pk_constraint(table).get("constrained_columns") or []
+            if pks:
+                pk_col = pks[0]
+            elif is_pg:
+                pk_col = _CANONICAL_PK.get(table)
+                if not pk_col or pk_col not in {
+                        c["name"] for c in insp.get_columns(table)}:
+                    raise RuntimeError(
+                        f"{table}: no primary key on PostgreSQL and no "
+                        f"canonical id column — cannot backfill safely")
+            else:
+                pk_col = "rowid"  # SQLite implicit rowid
+
+            rows = conn.execute(text(
+                f"SELECT {pk_col} FROM {table} WHERE node_uuid IS NULL"
+            )).fetchall()
+            for (row_id,) in rows:
+                conn.execute(
+                    text(f"UPDATE {table} SET node_uuid = :u "
+                         f"WHERE {pk_col} = :id"),
+                    {"u": _new_uuid(), "id": row_id},
+                )
+            counts[table] = len(rows)
+    return counts

--- a/scripts/requirements_wheels.txt
+++ b/scripts/requirements_wheels.txt
@@ -15,10 +15,13 @@ tzdata>=2025.1
 et-xmlfile==2.0.0
 fonttools>=4.57.0
 packaging==25.0
-s3dgraphy>=1.6.0.dev0,<1.7.0
+s3dgraphy>=1.6.0.dev6,<1.7.0
 # Constraint syntax (PEP 440):
-#   - `.dev0` lower bound EXPLICITLY allows pre-release versions for this
-#     package only (1.6.0.dev3, 1.6.0a1, 1.6.0rc1, 1.6.0, 1.6.1, ...).
+#   - `.dev6` lower bound EXPLICITLY allows pre-release versions for this
+#     package only (1.6.0.dev6, 1.6.0a1, 1.6.0rc1, 1.6.0, 1.6.1, ...).
+#     dev6 is the first build carrying the PyArchInit Postgres backend
+#     (PyArchInitImporter connection_url=) and s3dgraphy.sync.GraphIngestor
+#     that EM-tools Sub-2 / Sub-3 (issue #27) consume.
 #     No need for `--pre` globally (which would affect ALL packages).
 #   - `<1.7.0` upper bound prevents breaking-change surprises from a
 #     hypothetical future major release on the same minor line.
@@ -39,8 +42,23 @@ mmh3>=4.1.0
 # Note: OpenImageIO is optional for Tapestry - if not available, fallback to Blender's image API
 # Note: numpy and requests are already included in Blender 4.0+
 
-# pyarchinit dependency
+# PyArchInit Postgres backend (issue #27, Sub-2).
+#   - psycopg2-binary: the PostgreSQL driver used by s3dgraphy's
+#     PyArchInitImporter (connection_url=) and by the EM-tools geometry
+#     reader. Ships self-contained platform wheels (manylinux / macOS /
+#     win) for cp311 + cp313, so it bundles cleanly with the --no-deps
+#     download in setup_development.py.
+#   - keyring: optional, stores the PG password in the OS keychain. The
+#     code degrades to a session-memory fallback if keyring (or its
+#     platform backend) is missing, so a missing wheel never hard-breaks
+#     the import — it just means the password isn't persisted across
+#     sessions. (keyring has a few small transitive deps — jaraco.*,
+#     and SecretStorage/jeepney on Linux — that may need adding here for
+#     full keychain persistence; the fallback covers the gap meanwhile.)
+# NOTE: SQLAlchemy 2.x is intentionally NOT bundled here — it is only
+# needed by s3dgraphy.sync (GraphIngestor), which lands with Sub-3.
+psycopg2-binary>=2.9.9
+keyring>=24.0
+
 #pyarchinit-mini>=1.9.38
-#sqlalchemy==2.0.20
-# sqlalchemy dependency
 #typing_extensions==4.12.2

--- a/scripts/requirements_wheels.txt
+++ b/scripts/requirements_wheels.txt
@@ -55,8 +55,12 @@ mmh3>=4.1.0
 #     sessions. (keyring has a few small transitive deps — jaraco.*,
 #     and SecretStorage/jeepney on Linux — that may need adding here for
 #     full keychain persistence; the fallback covers the gap meanwhile.)
-# NOTE: SQLAlchemy 2.x is intentionally NOT bundled here — it is only
-# needed by s3dgraphy.sync (GraphIngestor), which lands with Sub-3.
+# SQLAlchemy 2.x + typing_extensions: required by s3dgraphy.sync
+# (GraphIngestor / DbHandle) for the reverse-export (issue #27, Sub-3).
+# typing_extensions is a hard runtime dependency of SQLAlchemy 2.0 and
+# must be bundled explicitly because setup downloads with --no-deps.
+SQLAlchemy>=2.0,<3.0
+typing_extensions>=4.6.0
 psycopg2-binary>=2.9.9
 keyring>=24.0
 

--- a/tests/test_import_validator_pg.py
+++ b/tests/test_import_validator_pg.py
@@ -1,0 +1,49 @@
+"""ImportValidator accepts a PostgreSQL connection_url for pyArchInit (#27).
+
+Regression guard for the 'Missing required field: filepath' error hit
+when importing in PostgreSQL mode (settings carry connection_url, not
+filepath).
+"""
+
+from import_operators.import_validator import ImportValidator
+
+
+def test_pyarchinit_accepts_connection_url():
+    settings = {
+        "import_type": "pyarchinit",
+        "connection_url": "postgresql+psycopg2://u:p@h:5432/db",
+        "mapping_name": "pyarchinit_us",
+    }
+    ok, err = ImportValidator.validate("pyarchinit", settings)
+    assert ok, err
+
+
+def test_pyarchinit_accepts_sqlite_filepath():
+    settings = {
+        "import_type": "pyarchinit",
+        "filepath": "/data/site.sqlite",
+        "mapping_name": "pyarchinit_us",
+    }
+    ok, err = ImportValidator.validate("pyarchinit", settings)
+    assert ok, err
+
+
+def test_pyarchinit_rejects_when_no_connection_source():
+    settings = {
+        "import_type": "pyarchinit",
+        "mapping_name": "pyarchinit_us",
+    }
+    ok, err = ImportValidator.validate("pyarchinit", settings)
+    assert not ok
+    assert "one of" in err.lower()
+
+
+def test_pyarchinit_still_requires_mapping():
+    settings = {
+        "import_type": "pyarchinit",
+        "connection_url": "postgresql://u:p@h/db",
+        "mapping_name": "none",
+    }
+    ok, err = ImportValidator.validate("pyarchinit", settings)
+    assert not ok
+    assert "mapping" in err.lower()

--- a/tests/test_pyarchinit_connection.py
+++ b/tests/test_pyarchinit_connection.py
@@ -1,0 +1,55 @@
+"""Unit tests for the PostgreSQL connection-spec helpers (issue #27).
+
+All Blender-free: the connection module never imports ``bpy`` and the
+keychain layer degrades to an in-memory fallback, so these run under a
+plain pytest invocation.
+"""
+
+from import_operators.pyarchinit_connection import (
+    build_connection_url,
+    account_id,
+    set_password,
+    get_password,
+    forget_password,
+)
+
+
+def test_build_url_basic():
+    url = build_connection_url("localhost", 5432, "pyarch", "enzo", "secret")
+    assert url == "postgresql+psycopg2://enzo:secret@localhost:5432/pyarch"
+
+
+def test_build_url_percent_encodes_password():
+    # A password with URL-reserved characters must not corrupt the URL.
+    url = build_connection_url("h", 5432, "db", "user", "p@ss:w/rd?")
+    assert "p%40ss%3Aw%2Frd%3F" in url
+    # The single literal '@' separating userinfo from host stays.
+    assert url.count("@") == 1
+
+
+def test_build_url_percent_encodes_user():
+    url = build_connection_url("h", 5432, "db", "do@main\\u", "pw")
+    assert "do%40main" in url
+
+
+def test_build_url_no_password():
+    url = build_connection_url("h", 5432, "db", "user", "")
+    assert url == "postgresql+psycopg2://user@h:5432/db"
+
+
+def test_build_url_default_host_and_optional_port():
+    url = build_connection_url("", None, "db", "user", "pw")
+    assert url == "postgresql+psycopg2://user:pw@localhost/db"
+
+
+def test_account_id_is_stable():
+    assert account_id("h", 5432, "db", "u") == "u@h:5432/db"
+
+
+def test_memory_fallback_roundtrip():
+    # When no OS keychain is present (typical CI), the helpers fall back
+    # to session memory — set/get/forget must still behave.
+    set_password("h", 5432, "db", "u", "topsecret")
+    assert get_password("h", 5432, "db", "u") == "topsecret"
+    forget_password("h", 5432, "db", "u")
+    assert get_password("h", 5432, "db", "u") is None

--- a/tests/test_pyarchinit_export.py
+++ b/tests/test_pyarchinit_export.py
@@ -1,0 +1,143 @@
+"""Unit tests for the PyArchInit reverse-export helpers (issue #27, Sub-3).
+
+Blender-free: the IngestResult formatter and the shared connection
+resolver are exercised with duck-typed objects.
+"""
+
+import importlib.util
+import os
+import types
+
+from import_operators.pyarchinit_connection import resolve_db_spec
+
+# result_format lives inside a package whose __init__ imports bpy-bound
+# operators; load the (Blender-free) module directly by path so this
+# test runs outside Blender.
+_RF_PATH = os.path.join(
+    os.path.dirname(__file__), "..",
+    "export_manager", "providers", "pyarchinit", "result_format.py",
+)
+_spec = importlib.util.spec_from_file_location("pyarchinit_result_format", _RF_PATH)
+_rf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_rf)
+format_ingest_result = _rf.format_ingest_result
+is_node_uuid_error = _rf.is_node_uuid_error
+node_uuid_help = _rf.node_uuid_help
+
+
+# --- node_uuid error guidance --------------------------------------------
+
+def test_is_node_uuid_error_detection():
+    assert is_node_uuid_error("us_table.node_uuid column missing — run …")
+    assert not is_node_uuid_error("some other failure")
+    assert not is_node_uuid_error("")
+    assert not is_node_uuid_error(None)
+
+
+def test_node_uuid_help_mentions_pyarchinit():
+    msg = node_uuid_help()
+    assert "PyArchInit" in msg
+    assert "node_uuid" in msg
+
+
+def test_node_uuid_help_appends_failure_reason():
+    msg = node_uuid_help("permission denied")
+    assert "permission denied" in msg
+
+
+class _Result:
+    def __init__(self, **kw):
+        self.applied = kw.get("applied", 0)
+        self.inserted = kw.get("inserted", 0)
+        self.updated = kw.get("updated", 0)
+        self.skipped = kw.get("skipped", 0)
+        self.epochs_created = kw.get("epochs_created", 0)
+        self.conflicts = kw.get("conflicts", ())
+        self.errors = kw.get("errors", ())
+        self.dry_run = kw.get("dry_run", False)
+
+
+# --- result formatter ----------------------------------------------------
+
+def test_format_dry_run_heading():
+    lines = format_ingest_result(_Result(inserted=3, applied=3), "sqlite:///x.sqlite", True)
+    assert lines[0].startswith("DRY-RUN")
+    assert any("Inserted:  3" in ln for ln in lines)
+
+
+def test_format_write_heading():
+    lines = format_ingest_result(_Result(applied=5), "postgresql://h/db", False)
+    assert "Export complete" in lines[0]
+    assert any("Target:" in ln and "postgresql://h/db" in ln for ln in lines)
+
+
+def test_format_conflicts_truncated():
+    conflicts = tuple(
+        types.SimpleNamespace(field=f"f{i}", node_uuid=f"n{i}",
+                              db_value="a", graph_value="b")
+        for i in range(7)
+    )
+    lines = format_ingest_result(_Result(conflicts=conflicts), "t", True)
+    assert any("Conflicts: 7" in ln for ln in lines)
+    assert any("and 2 more" in ln for ln in lines)
+
+
+def test_format_errors_listed():
+    lines = format_ingest_result(_Result(errors=("boom",)), "t", False)
+    assert any("Errors:" in ln for ln in lines)
+    assert any("boom" in ln for ln in lines)
+
+
+# --- shared connection resolver (export reuses the import config) --------
+
+def _em_tools(**kw):
+    defaults = dict(
+        pyarchinit_connection_mode="sqlite",
+        pyarchinit_db_path="",
+        pyarchinit_pg_host="", pyarchinit_pg_port=5432,
+        pyarchinit_pg_dbname="", pyarchinit_pg_user="",
+        pyarchinit_pg_password="",
+    )
+    defaults.update(kw)
+    return types.SimpleNamespace(**defaults)
+
+
+def test_resolve_sqlite_ok():
+    spec, err = resolve_db_spec(_em_tools(pyarchinit_db_path="/data/x.sqlite"))
+    assert err is None
+    assert spec == "/data/x.sqlite"
+
+
+def test_resolve_sqlite_missing_path():
+    spec, err = resolve_db_spec(_em_tools(pyarchinit_db_path=""))
+    assert spec is None
+    assert "SQLite" in err
+
+
+def test_resolve_postgres_ok():
+    spec, err = resolve_db_spec(_em_tools(
+        pyarchinit_connection_mode="postgres",
+        pyarchinit_pg_host="h", pyarchinit_pg_dbname="db",
+        pyarchinit_pg_user="u", pyarchinit_pg_password="pw",
+    ))
+    assert err is None
+    assert spec.startswith("postgresql+psycopg2://u:pw@h:5432/db")
+
+
+def test_resolve_postgres_missing_fields():
+    spec, err = resolve_db_spec(_em_tools(
+        pyarchinit_connection_mode="postgres",
+        pyarchinit_pg_host="h",  # missing db + user
+    ))
+    assert spec is None
+    assert "host, database and user" in err
+
+
+def test_resolve_postgres_missing_password():
+    spec, err = resolve_db_spec(_em_tools(
+        pyarchinit_connection_mode="postgres",
+        pyarchinit_pg_host="h", pyarchinit_pg_dbname="db",
+        pyarchinit_pg_user="u", pyarchinit_pg_password="",
+    ))
+    assert spec is None
+    assert "password" in err.lower()

--- a/tests/test_pyarchinit_migrate.py
+++ b/tests/test_pyarchinit_migrate.py
@@ -1,0 +1,66 @@
+"""Tests for the EMTools-side node_uuid migration (issue #27, Sub-3).
+
+Runs against a real temporary SQLite DB via SQLAlchemy (bundled), so it
+exercises the actual ALTER/INDEX/backfill SQL — no Blender needed.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+from sqlalchemy import create_engine, inspect, text  # noqa: E402
+
+from import_operators.pyarchinit_migrate import apply_node_uuid_migration  # noqa: E402
+
+
+def _make_sqlite_with_us():
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    eng = create_engine(f"sqlite:///{path}")
+    with eng.begin() as c:
+        c.execute(text(
+            "CREATE TABLE us_table (id_us INTEGER PRIMARY KEY, us INTEGER)"))
+        c.execute(text(
+            "INSERT INTO us_table (id_us, us) VALUES (1, 100), (2, 200)"))
+    return path
+
+
+def test_migration_adds_column_and_backfills():
+    path = _make_sqlite_with_us()
+    try:
+        counts = apply_node_uuid_migration(f"sqlite:///{path}")
+        assert counts.get("us_table") == 2
+        eng = create_engine(f"sqlite:///{path}")
+        cols = {c["name"] for c in inspect(eng).get_columns("us_table")}
+        assert "node_uuid" in cols
+        with eng.begin() as c:
+            nulls = c.execute(text(
+                "SELECT COUNT(*) FROM us_table WHERE node_uuid IS NULL")).scalar()
+            distinct = c.execute(text(
+                "SELECT COUNT(DISTINCT node_uuid) FROM us_table")).scalar()
+        assert nulls == 0
+        assert distinct == 2  # unique ids per row
+    finally:
+        os.remove(path)
+
+
+def test_migration_is_idempotent():
+    path = _make_sqlite_with_us()
+    try:
+        apply_node_uuid_migration(f"sqlite:///{path}")
+        counts2 = apply_node_uuid_migration(f"sqlite:///{path}")
+        assert counts2.get("us_table") == 0  # nothing left to backfill
+    finally:
+        os.remove(path)
+
+
+def test_migration_raises_when_no_pyarchinit_tables():
+    fd, path = tempfile.mkstemp(suffix=".sqlite")
+    os.close(fd)
+    try:
+        with pytest.raises(Exception):
+            apply_node_uuid_migration(f"sqlite:///{path}")
+    finally:
+        os.remove(path)

--- a/tests/test_pyarchinit_pg_reader.py
+++ b/tests/test_pyarchinit_pg_reader.py
@@ -1,0 +1,93 @@
+"""Unit tests for the PostgreSQL branch of pyarchinit_db_reader (#27).
+
+The live psycopg2 paths need a real PostGIS server (covered by the
+in-Blender / integration pass). Here we cover the pure-Python logic:
+backend detection, credential redaction, and the ``%s`` filter-clause
+builder — including its SQL-injection guard and alias translation.
+"""
+
+from import_operators.pyarchinit_db_reader import (
+    is_postgres_spec,
+    redacted_db_spec,
+    _build_filter_clause_pg,
+)
+
+
+# --- backend detection ---------------------------------------------------
+
+def test_is_postgres_spec_detects_urls():
+    assert is_postgres_spec("postgresql://u:p@h/db")
+    assert is_postgres_spec("postgresql+psycopg2://u:p@h/db")
+    assert is_postgres_spec("postgres://u:p@h/db")
+
+
+def test_is_postgres_spec_rejects_paths():
+    assert not is_postgres_spec("/data/site.sqlite")
+    assert not is_postgres_spec("sqlite:///data/site.sqlite")
+    assert not is_postgres_spec("")
+    assert not is_postgres_spec(None)
+
+
+# --- credential redaction ------------------------------------------------
+
+def test_redacted_strips_userinfo():
+    assert (redacted_db_spec("postgresql://enzo:secret@db.example.org:5432/pyarch")
+            == "postgresql://db.example.org:5432/pyarch")
+
+
+def test_redacted_keeps_driver_tag():
+    assert (redacted_db_spec("postgresql+psycopg2://u:p@h/db")
+            == "postgresql+psycopg2://h/db")
+
+
+def test_redacted_url_without_userinfo_is_unchanged():
+    assert (redacted_db_spec("postgresql://h:5432/db")
+            == "postgresql://h:5432/db")
+
+
+def test_redacted_leaves_sqlite_paths():
+    assert redacted_db_spec("/data/site.sqlite") == "/data/site.sqlite"
+
+
+# --- %s filter clause ----------------------------------------------------
+
+def test_filter_clause_empty():
+    where, params = _build_filter_clause_pg(None, "us_s", "area_s", "scavo_s")
+    assert where == ""
+    assert params == []
+
+
+def test_filter_clause_uses_percent_s_and_actual_columns():
+    where, params = _build_filter_clause_pg(
+        {"us": 5}, "us_s", "area_s", "scavo_s")
+    assert where == " WHERE us_s = %s"
+    assert params == [5]
+
+
+def test_filter_clause_translates_aliases():
+    # 'sito'/'scavo_s' both map to the detected sito column; 'area_s' to area.
+    where, params = _build_filter_clause_pg(
+        {"scavo_s": "SITE1", "area_s": "A"}, "us_s", "area_s", "scavo_s")
+    assert "scavo_s = %s" in where
+    assert "area_s = %s" in where
+    assert set(params) == {"SITE1", "A"}
+
+
+def test_filter_clause_skips_unknown_columns():
+    # A US-table-only filter column with no spatial-table equivalent is
+    # silently dropped (mirrors the SQLite builder).
+    where, params = _build_filter_clause_pg(
+        {"d_stratigrafica": "crollo"}, "us_s", "area_s", "scavo_s")
+    assert where == ""
+    assert params == []
+
+
+def test_filter_clause_value_is_parameterised_not_interpolated():
+    # SQL-injection guard: the malicious value travels as a bound param,
+    # never spliced into the SQL text.
+    evil = "'; DROP TABLE x; --"
+    where, params = _build_filter_clause_pg(
+        {"sito": evil}, "us_s", "area_s", "scavo_s")
+    assert where == " WHERE scavo_s = %s"
+    assert params == [evil]
+    assert "DROP TABLE" not in where


### PR DESCRIPTION
## PyArchInit DB reverse-export — Sub-3 of #27

Adds an **"Export to PyArchInit DB"** section to the Export panel that writes the active EM graph back into a PyArchInit database (SQLite or PostgreSQL) via `s3dgraphy.sync.GraphIngestor` (zalmoxes-laran/s3Dgraphy#11), with a **dry-run preview**.

![Sub-3 reverse-export demo](https://raw.githubusercontent.com/enzococca/EM-blender-tools/media/sub3-reverse-export-demo.gif)

> ⚠️ **Stacked on #28 (Sub-2).** This branch contains the Sub-2 commit (`191877b`, already under review in #28) plus the Sub-3 commit (`c0cc4c9`). Please merge #28 first; the Sub-3-specific changes are in `c0cc4c9`.

### What's in it
- **Export provider** (`export_manager/providers/pyarchinit/`): a new panel section with a **Site** field, a *Create missing epochs* toggle, and **Preview (dry run)** / **Export to PyArchInit DB** buttons. The connection is shared with the 3D GIS import panel (Sub-2), so a round-trip reads and writes the same DB with one config.
- **operators.py**: resolves the active graph + site + connection spec and calls `GraphIngestor().populate_list(graph, spec, sito, dry_run=…, create_missing_epochs=…)`. A SQLite path is turned into a `sqlite://` URL; a PG URL passes through. The yEd override hook is intentionally left unregistered (Blender has no yEd-raw use case → headless defaults).
- **result_format.py**: `IngestResult` → summary lines (applied / inserted / updated / skipped / epochs, conflicts, errors).

### `node_uuid` prerequisite handling
`s3dgraphy.sync` requires a `node_uuid` column on the PyArchInit tables (normally added by a **PyArchInit-side** migration). When it's missing:
- **Preview** never mutates the schema — it shows a clear message telling the user to update the DB from PyArchInit.
- **Export** attempts the migration best-effort (`pyarchinit_migrate.py`: add `node_uuid` + partial unique index + uuid backfill, via SQLAlchemy, SQLite+PG) and retries; on failure it falls back to the same message.

See #27 for the upstream gap (the migration script the error points at isn't shipped in the s3dgraphy wheel) and the remaining reverse-export parser roadmap.

### Packaging
Bundles **SQLAlchemy 2.x + typing_extensions** (`s3dgraphy.sync` runtime deps; setup downloads `--no-deps`).

### Testing
- 15 new Blender-free unit tests (IngestResult formatter, shared connection resolver, `node_uuid` migration against a real temp SQLite, error-guidance helpers). Full suite **59 passed**.
- Verified in Blender 5.1.2: preview + export against a PyArchInit DB (see GIF), including the auto-migration fallback when `node_uuid` is absent.

### Known limitations / remaining work (tracked in #27)
- The reverse-export still needs parser work to populate the **`rapporti`** column, write rapporti/epochs in a **PyArchInit-managed language**, and validate US relationships for **stratigraphic paradoxes** + **reciprocity**.

Part of #27 (Sub-3). Sub-2 is #28.
