### PR TITLE
feat(ci): archive stable releases to Zenodo via deposit API (master parity)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,12 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    # Crea una GitHub Release per OGNI tag: i pre-release (-dev/-rc/-alpha/-beta)
+    # come "prerelease", gli altri come stabili. Le pre-release sono necessarie per
+    # i link di download persistenti degli asset (/releases/download/<tag>/<file>).
+    # NB: l'archiviazione su Zenodo NON e' piu' gestita dal webhook repo-wide
+    # (va disattivato in Zenodo > Settings > GitHub): le release stabili vanno
+    # archiviate separatamente, cosi' le dev non finiscono su Zenodo.
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -254,3 +260,38 @@ jobs:
             Each package contains wheels compiled for a specific platform and Python version.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  zenodo:
+    needs: build
+    runs-on: ubuntu-latest
+    # Archivia su Zenodo SOLO le release STABILI (non -dev/-rc/-alpha/-beta),
+    # via API deposizioni -- NON il webhook (disattivato: dopo la migrazione a
+    # InvenioRDM falliva con errore vuoto). Job separato e NON bloccante: se
+    # fallisce, la GitHub Release e i link di download restano validi e quella
+    # stabile si archivia a mano. Richiede il secret ZENODO_TOKEN (scope
+    # deposit:write + deposit:actions); se manca, lo script salta senza errore.
+    if: >-
+      ${{ github.event_name == 'push'
+          && !contains(github.ref_name, '-dev')
+          && !contains(github.ref_name, '-rc')
+          && !contains(github.ref_name, '-alpha')
+          && !contains(github.ref_name, '-beta') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build source archive
+        run: |
+          TAG="${{ github.ref_name }}"
+          git archive --format=zip --prefix="EM-blender-tools-${TAG}/" HEAD \
+            -o "EM-blender-tools-${TAG}.zip"
+          ls -la "EM-blender-tools-${TAG}.zip"
+
+      - name: Publish source to Zenodo (stable only)
+        env:
+          ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+          ZENODO_CONCEPT: "4459272"
+          TAG: ${{ github.ref_name }}
+          SRC_ZIP: "EM-blender-tools-${{ github.ref_name }}.zip"
+        run: python3 scripts/zenodo_publish.py

--- a/scripts/zenodo_publish.py
+++ b/scripts/zenodo_publish.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Publish a new version of EM Tools to Zenodo via the deposit API.
+
+Runs in CI for STABLE tags only (the release.yml `zenodo` job). It archives the
+source archive of the tag as a new version under the existing concept DOI,
+bypassing the GitHub->Zenodo webhook (which broke after the InvenioRDM
+migration and fails with an empty error: {"errors": ""}).
+
+Design / robustness:
+  * Idempotent: if the concept already has a version equal to TAG, exit 0.
+  * Non-blocking: this is a standalone job, so if it fails the GitHub Release
+    and its download links are unaffected -- just archive that stable manually.
+  * Uses the deposit API (which returns real error messages), not the webhook.
+  * If ZENODO_TOKEN is empty/missing it SKIPS (exit 0) instead of failing, so
+    tagging a stable before the secret is configured won't break the build.
+
+Env:
+  ZENODO_TOKEN    Zenodo personal token (scopes: deposit:write, deposit:actions)
+  ZENODO_CONCEPT  concept record id (numeric), e.g. 4459272
+  TAG             the git tag, e.g. v1.6.0
+  SRC_ZIP         path to the source archive to upload
+Reads .zenodo.json (repo root) for the deposition metadata.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API = "https://zenodo.org/api"
+TOKEN = os.environ.get("ZENODO_TOKEN", "").strip()
+CONCEPT = os.environ.get("ZENODO_CONCEPT", "").strip()
+TAG = os.environ.get("TAG", "").strip()
+SRC_ZIP = os.environ.get("SRC_ZIP", "").strip()
+
+if not TOKEN:
+    print("ZENODO_TOKEN not set -> skipping Zenodo archival "
+          "(configure the repo secret to enable it).")
+    sys.exit(0)
+for _name, _val in (("ZENODO_CONCEPT", CONCEPT), ("TAG", TAG), ("SRC_ZIP", SRC_ZIP)):
+    if not _val:
+        print(f"ERROR: {_name} not set", file=sys.stderr)
+        sys.exit(1)
+
+
+def api(method, url, data=None, ctype=None):
+    headers = {"Authorization": f"Bearer {TOKEN}"}
+    if ctype:
+        headers["Content-Type"] = ctype
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read()
+            return resp.status, (json.loads(body) if body else {})
+    except urllib.error.HTTPError as exc:
+        body = exc.read()
+        try:
+            return exc.code, json.loads(body or b"{}")
+        except Exception:
+            return exc.code, {"_raw": body.decode("utf-8", "replace")}
+
+
+def die(msg):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+# 1. Resolve concept -> latest record; idempotency check.
+st, rec = api("GET", f"{API}/records/{CONCEPT}")
+if st != 200:
+    die(f"cannot resolve concept {CONCEPT}: HTTP {st} {rec}")
+latest_id = rec["id"]
+st, vers = api("GET", f"{API}/records/{latest_id}/versions?size=200&allversions=true")
+have = {v.get("metadata", {}).get("version")
+        for v in vers.get("hits", {}).get("hits", [])}
+if TAG in have:
+    print(f"Version {TAG} already archived on concept {CONCEPT} -> nothing to do.")
+    sys.exit(0)
+
+# 2. Metadata from .zenodo.json.
+with open(".zenodo.json", encoding="utf-8") as fh:
+    meta = json.load(fh)
+meta["version"] = TAG
+
+# 3. Create a new-version draft from the latest deposition.
+st, nv = api("POST", f"{API}/deposit/depositions/{latest_id}/actions/newversion")
+if st not in (200, 201):
+    die(f"newversion failed: HTTP {st} {nv}")
+draft_url = nv.get("links", {}).get("latest_draft")
+if not draft_url:
+    die(f"no latest_draft link returned: {nv}")
+st, draft = api("GET", draft_url)
+if st != 200:
+    die(f"get draft failed: HTTP {st} {draft}")
+draft_id = draft["id"]
+bucket = draft["links"]["bucket"]
+
+# 4. Set metadata.
+st, up = api("PUT", f"{API}/deposit/depositions/{draft_id}",
+             data=json.dumps({"metadata": meta}).encode("utf-8"),
+             ctype="application/json")
+if st != 200:
+    die(f"metadata update failed: HTTP {st} {up}")
+
+# 5. Drop inherited files (the previous version's source archive).
+for f in draft.get("files", []):
+    api("DELETE", f"{API}/deposit/depositions/{draft_id}/files/{f.get('id')}")
+
+# 6. Upload the new source archive to the draft's bucket.
+fname = os.path.basename(SRC_ZIP)
+with open(SRC_ZIP, "rb") as fh:
+    blob = fh.read()
+st, _ = api("PUT", f"{bucket}/{urllib.parse.quote(fname)}",
+            data=blob, ctype="application/octet-stream")
+if st not in (200, 201):
+    die(f"file upload failed for {fname}: HTTP {st}")
+print(f"Uploaded {fname} ({len(blob)} bytes)")
+
+# 7. Publish.
+st, pub = api("POST", f"{API}/deposit/depositions/{draft_id}/actions/publish")
+if st not in (200, 202):
+    die(f"publish failed: HTTP {st} {pub}")
+print("Published new version:", pub.get("doi") or pub.get("doi_url") or draft_id)


### PR DESCRIPTION
Porta su master il job CI \`zenodo\` + \`scripts/zenodo_publish.py\` gia presenti su \`EM-tools_v1.5.0\` e \`EM-tools_v1.6.0_dev\`.

- Archivia su Zenodo SOLO le release stabili, via API deposizioni (il webhook repo-wide e disattivato).
- Idempotente e non bloccante; richiede il secret repo \`ZENODO_TOKEN\`.
- Su master e **dormiente** (i tag non si tagliano da master): serve solo per coerenza del branch di default.

Nessun effetto finche non si crea una release stabile.
